### PR TITLE
fix: once item selected, trigger change event on original select element

### DIFF
--- a/src/js/avalynx-select.js
+++ b/src/js/avalynx-select.js
@@ -204,6 +204,8 @@ class AvalynxSelect {
             item.classList.add('active');
             button.textContent = selectedItemText;
             select.value = selectedItemValue;
+            // trigger the original select element's "change" event
+            select.dispatchEvent(new Event('change'));
             const searchInput = dropdown.querySelector('.avalynx-select-input');
             searchInput.value = '';
             button.classList.remove('text-muted');


### PR DESCRIPTION
this PR allows developer to listen on change event in the original select element.

```
select.dispatchEvent(new Event('change'));
```

FYI.

https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent
according to mdn, it's recommended to use `new Event(xxx)` instead of 'document.createEvent'