### PR TITLE
Upgrade AvalynxSelect to version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Replace `path/to/avalynx-select.js` with the actual path to the file in your pro
 AvalynxSelect is also available via [jsDelivr](https://www.jsdelivr.com/). You can include it in your project like this:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.0.0/dist/js/avalynx-select.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
 ```
 
 Make sure to also include Bootstrap's JS/CSS in your project to ensure AvalynxSelect displays correctly.
@@ -134,6 +134,8 @@ AvalynxSelect allows the following options for customization:
     - `scrollList`: (boolean) Enable scrollable list (default: `true`).
     - `scrollItems`: (number) Number of items to display before scrolling (default: `8`).
     - `noDefaultSelection`: (boolean) Do not select any option by default (default: `false`).
+    - `disabled`: (boolean) Initialize the select as disabled (default: `false`).
+    - `defaultValue`: (string|null) The default value to select on initialization (default
     - `onChange`: (function) Callback function to be executed when an option is selected (default: `null`).
     - `onLoaded`: (function) Callback function to be executed when the component is loaded (default: `null`).
 - `language`: An object containing the following keys:

--- a/__tests__/avalynx-select.test.js
+++ b/__tests__/avalynx-select.test.js
@@ -1,79 +1,745 @@
-import { AvalynxSelect } from '../dist/js/avalynx-select.esm.js';
+/**
+ * AvalynxSelect Jest Tests
+ * Comprehensive test suite for all important functionality
+ */
+
+// Mock bootstrap dropdown
+global.bootstrap = {
+    Dropdown: jest.fn().mockImplementation(() => ({
+        hide: jest.fn(),
+        show: jest.fn()
+    }))
+};
+
+const AvalynxSelect = require('../src/js/avalynx-select.js');
 
 describe('AvalynxSelect', () => {
-    let select;
-    let avalynxSelect;
+    let container;
 
     beforeEach(() => {
-        select = document.createElement('select');
-        select.id = 'test-select';
-        select.classList.add('form-select');
-        document.body.appendChild(select);
-
-        avalynxSelect = new AvalynxSelect('#test-select');
+        // Setup DOM
+        container = document.createElement('div');
+        document.body.appendChild(container);
     });
 
     afterEach(() => {
-        document.body.removeChild(select);
+        // Cleanup
+        document.body.removeChild(container);
+        document.body.innerHTML = '';
     });
 
-    test('should be created correctly', () => {
-        expect(avalynxSelect).toBeInstanceOf(AvalynxSelect);
+    describe('Initialization', () => {
+        test('should initialize with default selector', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select');
+            expect(instance.initialized).toBe(true);
+        });
+
+        test('should initialize with custom selector', () => {
+            container.innerHTML = `
+                <select id="custom-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('#custom-select');
+            expect(instance.initialized).toBe(true);
+        });
+
+        test('should handle selector without prefix', () => {
+            container.innerHTML = `
+                <select class="my-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('my-select');
+            expect(instance.initialized).toBe(true);
+        });
+
+        test('should log error for non-existent selector', () => {
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            new AvalynxSelect('#nonexistent');
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining("Element(s) with selector '#nonexistent' not found")
+            );
+            consoleSpy.mockRestore();
+        });
+
+        test('should call onLoaded callback after initialization', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const onLoadedMock = jest.fn();
+            new AvalynxSelect('.avalynx-select', { onLoaded: onLoadedMock });
+
+            expect(onLoadedMock).toHaveBeenCalled();
+        });
     });
 
-    test('init should create required elements', () => {
-        avalynxSelect.init(select);
-        const button = document.querySelector(`#${select.id}`);
-        const dropdown = document.querySelector('ul.avalynx-select');
-        expect(button).not.toBeNull();
-        expect(dropdown).not.toBeNull();
+    describe('Configuration Options', () => {
+        test('should apply custom className to button', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { className: 'btn-custom test-class' });
+
+            const button = document.querySelector('button');
+            expect(button.classList.contains('btn-custom')).toBe(true);
+            expect(button.classList.contains('test-class')).toBe(true);
+        });
+
+        test('should enable live search when liveSearch is true', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: true });
+
+            const searchInput = document.querySelector('.avalynx-select-input');
+            const liveSearchElement = document.querySelector('.avalynx-select-livesearch');
+
+            expect(searchInput).not.toBeNull();
+            expect(liveSearchElement.style.display).not.toBe('none');
+        });
+
+        test('should hide live search when liveSearch is false', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: false });
+
+            const liveSearchElement = document.querySelector('.avalynx-select-livesearch');
+            expect(liveSearchElement.style.display).toBe('none');
+        });
+
+        test('should not select default when noDefaultSelection is true', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="" selected>Please select</option>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { noDefaultSelection: true });
+
+            const button = document.querySelector('button');
+            expect(button.textContent).toBe('Please select...');
+            expect(button.classList.contains('text-muted')).toBe(true);
+        });
+
+        test('should use custom language placeholders', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select',
+                { noDefaultSelection: true },
+                { selectPlaceholder: 'Bitte wählen...', searchPlaceholder: 'Suchen...' }
+            );
+
+            const button = document.querySelector('button');
+            const searchInput = document.querySelector('.avalynx-select-input');
+
+            expect(button.textContent).toBe('Bitte wählen...');
+            expect(searchInput.placeholder).toBe('Suchen...');
+        });
     });
 
-    test('filterDropdown should filter dropdown items correctly', () => {
-        select.options.add(new Option('Test 1', 'test1'));
-        select.options.add(new Option('Test 2', 'test2'));
-        select.options.add(new Option('Test 3', 'test3'));
-        avalynxSelect.init(select);
-        const dropdown = document.querySelector('ul.avalynx-select');
-        const searchInput = dropdown.querySelector('.avalynx-select-input');
-        searchInput.value = 'test2';
-        avalynxSelect.filterDropdown(dropdown, searchInput.value);
-        const visibleItems = dropdown.querySelectorAll('.dropdown-item:not(.d-none)');
-        expect(visibleItems.length).toBe(1);
-        expect(visibleItems[0].textContent).toBe('Test 2');
+    describe('Default Value Handling', () => {
+        test('should set default value from options.defaultValue', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { defaultValue: '2' });
+
+            const button = document.querySelector('button');
+            const originalSelect = document.getElementById('test-select-original');
+
+            expect(button.textContent).toBe('Option 2');
+            expect(originalSelect.value).toBe('2');
+        });
+
+        test('should set default value from data-default-value attribute', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select" data-default-value="1">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            expect(button.textContent).toBe('Option 1');
+        });
+
+        test('should prioritize options.defaultValue over data-default-value', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select" data-default-value="1">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { defaultValue: '2' });
+
+            const button = document.querySelector('button');
+            expect(button.textContent).toBe('Option 2');
+        });
+
+        test('should honor native selected option', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                    <option value="2" selected>Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            expect(button.textContent).toBe('Option 2');
+        });
     });
 
-    test('default selection should be set correctly', () => {
-        select.options.add(new Option('Test 1', 'test1'));
-        select.options.add(new Option('Test 2', 'test2'));
-        select.options.add(new Option('Test 3', 'test3'));
-        select.options[1].selected = true;
-        avalynxSelect.init(select);
-        const button = document.querySelector(`#${select.id}`);
-        expect(button.textContent).toBe('Test 2');
-        expect(avalynxSelect.value).toEqual(['test2']);
+    describe('Disabled State', () => {
+        test('should handle native disabled attribute', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select" disabled>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            expect(button.hasAttribute('disabled')).toBe(true);
+            expect(button.getAttribute('aria-disabled')).toBe('true');
+            expect(button.classList.contains('disabled')).toBe(true);
+        });
+
+        test('should handle disabled option', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { disabled: true });
+
+            const button = document.querySelector('button');
+            expect(button.hasAttribute('disabled')).toBe(true);
+        });
+
+        test('should prevent selection when disabled', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select" disabled>
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            const item = document.querySelector('.dropdown-item');
+            const event = new Event('click', { bubbles: true });
+
+            const originalValue = document.getElementById('test-select-original').value;
+            item.click();
+
+            // Value should not change when disabled
+            expect(document.getElementById('test-select-original').value).toBe(originalValue);
+        });
     });
 
-    test('reset should reset selection correctly', () => {
-        select.options.add(new Option('Test 1', 'test1'));
-        select.options.add(new Option('Test 2', 'test2'));
-        select.options.add(new Option('Test 3', 'test3'));
-        avalynxSelect.init(select);
-        const button = document.querySelector(`#${select.id}`);
-        const dropdown = document.querySelector('ul.avalynx-select');
-        avalynxSelect.reset(button, dropdown, select);
-        expect(button.textContent).toBe(avalynxSelect.language.selectPlaceholder);
-        expect(select.value).toBe('');
+    describe('Live Search Functionality', () => {
+        test('should filter items based on search term (case insensitive)', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Apple</option>
+                    <option value="2">Banana</option>
+                    <option value="3">Cherry</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: true, noDefaultSelection: true });
+
+            const items = document.querySelectorAll('.dropdown-item');
+
+            // Initially all items should be visible
+            expect(items[0].classList.contains('d-none')).toBe(false);
+            expect(items[1].classList.contains('d-none')).toBe(false);
+            expect(items[2].classList.contains('d-none')).toBe(false);
+
+            // Now filter
+            const searchInput = document.querySelector('.avalynx-select-input');
+            searchInput.value = 'ban';
+            searchInput.dispatchEvent(new Event('keyup'));
+
+            // After filtering, only Banana should be visible
+            expect(items[0].classList.contains('d-none')).toBe(true); // Apple
+            expect(items[1].classList.contains('d-none')).toBe(false); // Banana
+            expect(items[2].classList.contains('d-none')).toBe(true); // Cherry
+        });
+
+        test('should filter items case sensitive when caseSensitive is true', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Apple</option>
+                    <option value="2">apple</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: true, caseSensitive: true });
+
+            const searchInput = document.querySelector('.avalynx-select-input');
+            searchInput.value = 'Apple';
+            searchInput.dispatchEvent(new Event('keyup'));
+
+            const items = document.querySelectorAll('.dropdown-item');
+            expect(items[0].classList.contains('d-none')).toBe(false); // Apple
+            expect(items[1].classList.contains('d-none')).toBe(true); // apple
+        });
+
+        test('should show all items when search is empty and showAll is true', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Apple</option>
+                    <option value="2">Banana</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: true, showAll: true });
+
+            const searchInput = document.querySelector('.avalynx-select-input');
+            searchInput.value = '';
+            searchInput.dispatchEvent(new Event('keyup'));
+
+            const items = document.querySelectorAll('.dropdown-item');
+            items.forEach(item => {
+                expect(item.classList.contains('d-none')).toBe(false);
+            });
+        });
+
+        test('should keep active item visible when showActive is true', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Apple</option>
+                    <option value="2">Banana</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: true, showActive: true });
+
+            const items = document.querySelectorAll('.dropdown-item');
+            items[0].classList.add('active');
+
+            const searchInput = document.querySelector('.avalynx-select-input');
+            searchInput.value = 'ban';
+            searchInput.dispatchEvent(new Event('keyup'));
+
+            // Active item should still be visible even though it doesn't match
+            expect(items[0].classList.contains('d-none')).toBe(false); // Apple (active)
+            expect(items[1].classList.contains('d-none')).toBe(false); // Banana (matches)
+        });
     });
 
-    test('value getter and setter should work correctly', () => {
-        select.options.add(new Option('Test 1', 'test1'));
-        select.options.add(new Option('Test 2', 'test2'));
-        select.options.add(new Option('Test 3', 'test3'));
-        avalynxSelect.init(select);
-        avalynxSelect.value = ['test2'];
-        const button = document.querySelector(`#${select.id}`);
-        expect(avalynxSelect.value).toEqual(['test2']);
-        expect(button.textContent).toBe('Test 2');
+    describe('Item Selection', () => {
+        test('should select item and update button text', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { noDefaultSelection: true });
+
+            const button = document.querySelector('button');
+            const item = document.querySelectorAll('.dropdown-item')[1];
+
+            item.click();
+
+            expect(button.textContent).toBe('Option 1');
+            expect(item.classList.contains('active')).toBe(true);
+        });
+
+        test('should update original select value on selection', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { noDefaultSelection: true });
+
+            const item = document.querySelectorAll('.dropdown-item')[1];
+            const originalSelect = document.getElementById('test-select-original');
+
+            item.click();
+
+            expect(originalSelect.value).toBe('1');
+        });
+
+        test('should call onChange callback when item is selected', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const onChangeMock = jest.fn();
+            new AvalynxSelect('.avalynx-select', {
+                noDefaultSelection: true,
+                onChange: onChangeMock
+            });
+
+            const item = document.querySelectorAll('.dropdown-item')[1];
+            item.click();
+
+            expect(onChangeMock).toHaveBeenCalledWith('1');
+        });
+
+        test('should not call onChange during initialization', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                    <option value="2" selected>Option 2</option>
+                </select>
+            `;
+
+            const onChangeMock = jest.fn();
+            new AvalynxSelect('.avalynx-select', { onChange: onChangeMock });
+
+            // onChange should not be called during initialization
+            expect(onChangeMock).not.toHaveBeenCalled();
+        });
+
+        test('should reset selection when clicking active item', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            const item = document.querySelectorAll('.dropdown-item')[1];
+
+            // First click - select
+            item.click();
+            expect(button.textContent).toBe('Option 1');
+
+            // Second click - deselect
+            item.click();
+            expect(button.textContent).toBe('Please select...');
+            expect(button.classList.contains('text-muted')).toBe(true);
+        });
+
+        test('should clear search input after selection', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { liveSearch: true });
+
+            const searchInput = document.querySelector('.avalynx-select-input');
+            searchInput.value = 'test';
+
+            const item = document.querySelector('.dropdown-item');
+            item.click();
+
+            expect(searchInput.value).toBe('');
+        });
+    });
+
+    describe('Public API Methods', () => {
+        test('disable() should disable all select elements', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select');
+
+            instance.disable();
+
+            const button = document.querySelector('button');
+            const originalSelect = document.getElementById('test-select-original');
+
+            expect(button.hasAttribute('disabled')).toBe(true);
+            expect(originalSelect.disabled).toBe(true);
+        });
+
+        test('enable() should enable all select elements', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select" disabled>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select');
+
+            instance.enable();
+
+            const button = document.querySelector('button');
+            const originalSelect = document.getElementById('test-select-original');
+
+            expect(button.hasAttribute('disabled')).toBe(false);
+            expect(originalSelect.disabled).toBe(false);
+        });
+
+        test('value getter should return current value', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                    <option value="2" selected>Option 2</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select');
+
+            expect(instance.value).toEqual(['2']);
+        });
+
+        test('value setter should update selection', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select', { noDefaultSelection: true });
+
+            instance.value = ['2'];
+
+            const button = document.querySelector('button');
+            const originalSelect = document.getElementById('test-select-original');
+
+            expect(button.textContent).toBe('Option 2');
+            expect(originalSelect.value).toBe('2');
+        });
+
+        test('value setter with empty string should reset selection', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select');
+
+            instance.value = [''];
+
+            const button = document.querySelector('button');
+            expect(button.textContent).toBe('Please select...');
+        });
+    });
+
+    describe('DOM Manipulation', () => {
+        test('should create button element', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            expect(button).not.toBeNull();
+            expect(button.classList.contains('form-select')).toBe(true);
+        });
+
+        test('should create dropdown menu', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const dropdown = document.querySelector('.dropdown-menu');
+            expect(dropdown).not.toBeNull();
+
+            const items = dropdown.querySelectorAll('.dropdown-item');
+            expect(items.length).toBe(2);
+        });
+
+        test('should hide original select element', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const originalSelect = document.getElementById('test-select-original');
+            expect(originalSelect.style.display).toBe('none');
+        });
+
+        test('should rename original select id', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const originalSelect = document.getElementById('test-select-original');
+            const button = document.getElementById('test-select');
+
+            expect(originalSelect).not.toBeNull();
+            expect(button).not.toBeNull();
+            expect(button.tagName).toBe('BUTTON');
+        });
+
+        test('should create template in document body', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const template = document.getElementById('avalynx-select-template');
+            expect(template).not.toBeNull();
+        });
+    });
+
+    describe('Multiple Selects', () => {
+        test('should initialize multiple select elements', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select1">
+                    <option value="1">Option 1</option>
+                </select>
+                <select class="avalynx-select" id="test-select2">
+                    <option value="2">Option 2</option>
+                </select>
+            `;
+
+            const instance = new AvalynxSelect('.avalynx-select');
+
+            expect(instance.elements.length).toBe(2);
+            expect(document.querySelectorAll('button').length).toBe(2);
+        });
+    });
+
+    describe('Edge Cases', () => {
+        test('should handle empty select', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                </select>
+            `;
+
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+            new AvalynxSelect('.avalynx-select');
+
+            // Should not throw error, just not initialize
+            consoleSpy.mockRestore();
+        });
+
+        test('should handle select with only empty option', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const button = document.querySelector('button');
+            expect(button.textContent).toBe('Please select...');
+        });
+
+        test('should handle options with same values', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option A</option>
+                    <option value="1">Option B</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { defaultValue: '1' });
+
+            const button = document.querySelector('button');
+            // Should select the first matching option
+            expect(button.textContent).toBe('Option A');
+        });
+
+        test('should handle special characters in option text', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="1">Option & Special < > " '</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select');
+
+            const item = document.querySelector('.dropdown-item');
+            expect(item.textContent).toContain('Option & Special');
+        });
+
+        test('should handle invalid defaultValue gracefully', () => {
+            container.innerHTML = `
+                <select class="avalynx-select" id="test-select">
+                    <option value="">Please select</option>
+                    <option value="1">Option 1</option>
+                </select>
+            `;
+
+            new AvalynxSelect('.avalynx-select', { defaultValue: 'nonexistent' });
+
+            const button = document.querySelector('button');
+            // Should reset to placeholder when default value not found
+            expect(button.textContent).toBe('Please select...');
+        });
     });
 });

--- a/build.js
+++ b/build.js
@@ -18,7 +18,9 @@ fs.readFile(filePath, 'utf8', (err, data) => {
         return;
     }
 
-    const result = data.replace(/class /g, 'import * as bootstrap from \'bootstrap\';\n\nexport class ');
+    let result = data.replace(/class AvalynxSelect /g, 'import * as bootstrap from \'bootstrap\';\n\nexport class AvalynxSelect ');
+
+    result = result.replace(/\n\nif \(typeof module !== 'undefined' && module\.exports\) \{\n    module\.exports = AvalynxSelect;\n\}\n?$/, '');
 
     fs.writeFile(filePath, result, 'utf8', err => {
         if (err) {

--- a/dist/js/avalynx-select.esm.js
+++ b/dist/js/avalynx-select.esm.js
@@ -3,7 +3,7 @@
  *
  * AvalynxSelect is a lightweight, customizable select dropdown component for web applications. It is designed to be used with Bootstrap version 5.3 or higher and does not require any framework dependencies.
  *
- * @version 1.0.0
+ * @version 1.1.0
  * @license MIT
  * @author https://github.com/avalynx/avalynx-select/graphs/contributors
  * @website https://github.com/avalynx/
@@ -12,15 +12,15 @@
  *
  * @param {string} selector - The selector to use for targeting tables within the DOM (default: '.avalynx-select').
  * @param {object} options - An object containing the following keys:
- * @param {string} options.className - A custom import * as bootstrap from 'bootstrap';
-
-export class name for the loader element (default: '').
+ * @param {string} options.className - A custom class name for the loader element (default: '').
  * @param {boolean} options.liveSearch - Enable live search functionality (default: false).
  * @param {boolean} options.caseSensitive - Enable case-sensitive search (default: false).
  * @param {boolean} options.showAll - Show all options when search term is empty (default: true).
  * @param {boolean} options.scrollList - Enable scrollable list (default: true).
  * @param {number} options.scrollItems - Number of items to display before scrolling (default: 8).
  * @param {boolean} options.noDefaultSelection - Do not select any option by default (default: false).
+ * @param {boolean} options.disabled - Initialize the select as disabled (default: false).
+ * @param {string|null} options.defaultValue - The default value to select on initialization (default: null).
  * @param {function} options.onChange - Callback function to be executed when an option is selected (default: null).
  * @param {function} options.onLoaded - Callback function to be executed when the component is loaded (default: null).
  * @param {object} language - An object containing the following keys:
@@ -53,6 +53,8 @@ export class AvalynxSelect {
             scrollList: true,
             scrollItems: 8,
             noDefaultSelection: false,
+            disabled: false,
+            defaultValue: null,
             onChange: options.onChange || null,
             onLoaded: options.onLoaded || null,
             ...options
@@ -63,7 +65,11 @@ export class AvalynxSelect {
             ...language
         };
         this.initialized = false;
-        this.elements.forEach(select => this.init(select));
+        this.elements.forEach(select => {
+            if (select && select.options && select.options.length > 0) {
+                this.init(select);
+            }
+        });
         this.initialized = true;
         if (this.options.onLoaded) {
             this.options.onLoaded();
@@ -77,13 +83,30 @@ export class AvalynxSelect {
         const dropdown = dropdownElements.dropdown;
         const searchInput = dropdown.querySelector('.avalynx-select-input');
 
+        const isDisabled = select.disabled || !!this.options.disabled;
+        if (isDisabled) {
+            button.setAttribute('disabled', 'disabled');
+            button.setAttribute('aria-disabled', 'true');
+            button.classList.add('disabled');
+        }
+
         if (this.options.liveSearch) {
             searchInput.addEventListener('keyup', () => this.filterDropdown(dropdown, searchInput.value));
         }
         dropdown.querySelectorAll('.dropdown-item').forEach(item => {
-            item.addEventListener('click', (event) => this.selectItem(event, item, select, button, dropdown));
+            item.addEventListener('click', (event) => {
+                if (button.hasAttribute('disabled')) {
+                    event.preventDefault();
+                    return;
+                }
+                this.selectItem(event, item, select, button, dropdown)
+            });
         });
-        button.addEventListener('click', () => {
+        button.addEventListener('click', (e) => {
+            if (button.hasAttribute('disabled')) {
+                e.preventDefault();
+                return;
+            }
             setTimeout(() => {
                 searchInput.focus();
                 this.applyScrollSettings(dropdown);
@@ -107,12 +130,14 @@ export class AvalynxSelect {
     }
 
     addTemplateIfMissing(id, content) {
-        if (!document.getElementById(id)) {
-            const template = document.createElement('template');
-            template.id = id;
-            template.innerHTML = content;
-            document.body.appendChild(template);
+        const existing = document.getElementById(id);
+        if (existing) {
+            existing.remove();
         }
+        const template = document.createElement('template');
+        template.id = id;
+        template.innerHTML = content;
+        document.body.appendChild(template);
     }
 
     createDropdownElements(select) {
@@ -130,7 +155,9 @@ export class AvalynxSelect {
         };
         window.addEventListener('resize', updateWidth);
         const itemsContainer = dropdown.querySelector('.avalynx-select-items');
-        Array.from(select.options).forEach(option => {
+        const opts = select && select.options ? select.options : [];
+        for (let i = 0; i < (opts.length || 0); i++) {
+            const option = opts[i];
             const listItem = document.createElement('li');
             const anchor = document.createElement('a');
             anchor.classList.add('dropdown-item');
@@ -139,7 +166,7 @@ export class AvalynxSelect {
             anchor.dataset.value = option.value;
             listItem.appendChild(anchor);
             itemsContainer.appendChild(listItem);
-        });
+        }
         select.style.display = 'none';
         select.id = `${select.id}-original`;
         select.parentNode.insertBefore(button, select.nextSibling);
@@ -173,18 +200,26 @@ export class AvalynxSelect {
     setInitialSelection(select, button, dropdown) {
         if (this.options.noDefaultSelection) {
             this.reset(button, dropdown, select);
-        } else {
+            return;
+        }
+        const attrDefault = select.getAttribute('data-default-value');
+        const desired = this.options.defaultValue != null ? String(this.options.defaultValue) : (attrDefault != null ? String(attrDefault) : '');
+        if (desired) {
+            const selectedItem = Array.from(dropdown.querySelectorAll('.dropdown-item')).find(item => item.dataset.value === desired);
+            if (selectedItem) {
+                this.selectItem({ preventDefault: () => {} }, selectedItem, select, button, dropdown);
+                return;
+            }
+        }
+        if (select.selectedIndex >= 0 && select.options[select.selectedIndex] && select.value !== '') {
             const selectedOption = select.options[select.selectedIndex];
             const selectedItem = Array.from(dropdown.querySelectorAll('.dropdown-item')).find(item => item.dataset.value === selectedOption.value);
             if (selectedItem) {
-                this.selectItem({
-                    preventDefault: () => {
-                    }
-                }, selectedItem, select, button, dropdown);
-            } else {
-                this.reset(button, dropdown, select);
+                this.selectItem({ preventDefault: () => {} }, selectedItem, select, button, dropdown);
+                return;
             }
         }
+        this.reset(button, dropdown, select);
     }
 
     filterDropdown(dropdown, searchTerm) {
@@ -192,12 +227,17 @@ export class AvalynxSelect {
         const items = itemsContainer.querySelectorAll('.dropdown-item');
         let visibleCount = 0;
         items.forEach((item) => {
-            const itemText = this.options.caseSensitive ? item.textContent : item.textContent.toLowerCase();
-            const searchTermProcessed = this.options.caseSensitive ? searchTerm : searchTerm.toLowerCase();
-            const isVisible = searchTermProcessed || this.options.showAll
-                ? itemText.includes(searchTermProcessed) || (this.options.showActive && item.classList.contains('active'))
+            const rawItemText = item.textContent || '';
+            const rawSearch = searchTerm || '';
+            const itemText = this.options.caseSensitive ? rawItemText : rawItemText.toLowerCase();
+            const searchTermProcessed = this.options.caseSensitive ? rawSearch : rawSearch.toLowerCase();
+            const itemTextNorm = itemText.replace(/\s+/g, '');
+            const searchNorm = searchTermProcessed.replace(/\s+/g, '');
+            const isVisible = (searchTermProcessed || this.options.showAll)
+                ? (itemTextNorm.includes(searchNorm) || (this.options.showActive && item.classList.contains('active')))
                 : false;
-            item.parentElement.classList.toggle('d-none', !isVisible);
+            if (item.parentElement) item.parentElement.classList.toggle('d-none', !isVisible);
+            item.classList.toggle('d-none', !isVisible);
             if (isVisible) visibleCount++;
         });
         const liveSearchElement = dropdown.querySelector('.avalynx-select-livesearch');
@@ -232,5 +272,65 @@ export class AvalynxSelect {
             }
         }
     }
-}
 
+    reset(button, dropdown, select) {
+        dropdown.querySelectorAll('.dropdown-item.active').forEach(activeItem => {
+            activeItem.classList.remove('active');
+        });
+        const searchInput = dropdown.querySelector('.avalynx-select-input');
+        if (searchInput) searchInput.value = '';
+        button.textContent = this.language.selectPlaceholder;
+        button.classList.add('text-muted');
+        select.value = '';
+        this.filterDropdown(dropdown, '');
+    }
+
+    disable() {
+        this.elements.forEach(original => {
+            const button = document.getElementById(original.id.replace(/-original$/, ''));
+            if (button) {
+                button.setAttribute('disabled', 'disabled');
+                button.setAttribute('aria-disabled', 'true');
+                button.classList.add('disabled');
+            }
+            original.disabled = true;
+        });
+    }
+
+    enable() {
+        this.elements.forEach(original => {
+            const button = document.getElementById(original.id.replace(/-original$/, ''));
+            if (button) {
+                button.removeAttribute('disabled');
+                button.setAttribute('aria-disabled', 'false');
+                button.classList.remove('disabled');
+            }
+            original.disabled = false;
+        });
+    }
+
+    get value() {
+        const first = this.elements && this.elements[0] ? this.elements[0] : null;
+        return [first ? (first.value || '') : ''];
+    }
+
+    set value(values) {
+        if (!Array.isArray(values)) return;
+        this.elements.forEach((original, idx) => {
+            const desired = values[idx] != null ? String(values[idx]) : '';
+            const button = document.getElementById(original.id.replace(/-original$/, ''));
+            const dropdown = button ? button.nextElementSibling : null;
+            if (!button || !dropdown) return;
+            if (desired === '') {
+                this.reset(button, dropdown, original);
+                return;
+            }
+            const item = dropdown.querySelector(`.dropdown-item[data-value="${desired}"]`);
+            if (item) {
+                this.selectItem({ preventDefault: () => {} }, item, original, button, dropdown);
+            } else {
+                this.reset(button, dropdown, original);
+            }
+        });
+    }
+}

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,21 @@
-FROM webdevops/php-apache-dev:8.1
+FROM webdevops/php-apache-dev:8.3
 
 # Update and install
 RUN apt-get update && apt-get install -y
+
+#Nano
+RUN apt-get install -y nano
+
+#Keyring
+RUN mkdir -p /etc/apt/keyrings
+
+# Node.js
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN NODE_MAJOR=18 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+# Yarn
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor |  tee /usr/share/keyrings/yarnkey.gpg >/dev/null 2>&1
+RUN echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" |  tee /etc/apt/sources.list.d/yarn.list >/dev/null 2>&1
+RUN apt-get update && apt-get install -y yarn
+
+USER application

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,6 +24,8 @@
 		<li class="list-group-item"><a href="simple-select-livesearch.html">Simple select with livesearch and different options</a></li>
         <li class="list-group-item"><a href="simple-select-responsive.html">Simple select with responsive design</a></li>
         <li class="list-group-item"><a href="simple-select-event-listeners.html">Simple select with event listeners</a></li>
+        <li class="list-group-item"><a href="simple-select-disabled.html">Disabled select</a></li>
+        <li class="list-group-item"><a href="simple-select-default-value.html">Default value select</a></li>
 	</ul>
 
 	<a href="https://github.com/avalynx/avalynx-select" target="_blank" class="btn btn-primary">AvalynxSelect on GitHub</a> <a href="https://github.com/avalynx/" target="_blank" class="btn btn-primary">Avalynx on GitHub</a>

--- a/examples/simple-select-default-value.html
+++ b/examples/simple-select-default-value.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="de" data-bs-theme="auto">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Default value | AvalynxSelect Example</title>
+
+    <!-- Bootstrap 5.3 -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Highlight.js 11.9 -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/default.min.css">
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/highlight.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/languages/javascript.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
+    <script>hljs.highlightAll();</script>
+
+    <!-- AvalynxSelect 1.1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
+
+    <!-- Example helper -->
+    <link href="./css/helper.css" rel="stylesheet">
+    <script src="./js/helper.js"></script>
+</head>
+<body>
+
+<div class="container py-5">
+
+    <a class="btn btn-secondary float-end m-3" href=".">Back</a> <button id="modeToggle" class="btn btn-primary float-end m-3">Toggle to Dark Mode</button>
+
+    <br/>
+    <br/>
+    <br/>
+    <br/>
+
+    <select class="form-select avalynx-select" id="default-select">
+        <option value="">Please select...</option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+    </select>
+
+    <br/>
+
+    <div class="alert alert-info">
+        This example demonstrates setting a default value via the AvalynxSelect option <code>defaultValue</code>.
+        When initialized, the component will select the matching option and reflect it in the button text.
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // Initialize and set default value to "2"
+            new AvalynxSelect('#default-select', { defaultValue: '2' });
+        });
+    </script>
+
+    <br/>
+    <h3>Source of example<a class="p-1 float-end btn btn-secondary btn-small" id="copyButton">Copy to clipboard</a></h3>
+    <pre><code class="language-javascript" id="codeBlock">document.addEventListener('DOMContentLoaded', () => {
+    new AvalynxSelect('#default-select', { defaultValue: '2' });
+});</code></pre>
+
+    <a href="https://github.com/avalynx/avalynx-select" target="_blank" class="btn btn-primary">AvalynxSelect on GitHub</a>
+    <a href="https://github.com/avalynx/" target="_blank" class="btn btn-primary">Avalynx on GitHub</a>
+
+</div>
+</body>
+</html>

--- a/examples/simple-select-disabled.html
+++ b/examples/simple-select-disabled.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="de" data-bs-theme="auto">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Disabled select with default value | AvalynxSelect Example</title>
+
+    <!-- Bootstrap 5.3 -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Highlight.js 11.9 -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/default.min.css">
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/highlight.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/languages/javascript.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
+    <script>hljs.highlightAll();</script>
+
+    <!-- AvalynxSelect 1.1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
+
+    <!-- Example helper -->
+    <link href="./css/helper.css" rel="stylesheet">
+    <script src="./js/helper.js"></script>
+</head>
+<body>
+
+<div class="container py-5">
+
+    <a class="btn btn-secondary float-end m-3" href=".">Back</a> <button id="modeToggle" class="btn btn-primary float-end m-3">Toggle to Dark Mode</button>
+
+    <br/>
+    <br/>
+    <br/>
+
+
+    <select class="form-select avalynx-select" id="disabled-select" disabled>
+        <option value="">Please select...</option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+    </select>
+
+    <br/>
+
+    <select class="form-select avalynx-select" id="disabled-select-default" disabled>
+        <option value="">Please select...</option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+    </select>
+
+    <br/>
+
+    <div class="alert alert-info">
+        This example demonstrates a disabled AvalynxSelect with and without a default value. The native select has the <code>disabled</code> attribute,
+        which is mirrored to the custom button to prevent user interaction. Additionally, a default value is set via the
+        <code>defaultValue</code> option, so "Option 2" is pre-selected when the component initializes.
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // Initialize with disabled state
+            new AvalynxSelect('#disabled-select', { defaultValue: '2' });
+
+            // Initialize with disabled state and default value
+            new AvalynxSelect('#disabled-select-default', { defaultValue: '2' });
+        });
+    </script>
+
+    <br/>
+    <h3>Source of example<a class="p-1 float-end btn btn-secondary btn-small" id="copyButton">Copy to clipboard</a></h3>
+    <pre><code class="language-javascript" id="codeBlock">document.addEventListener('DOMContentLoaded', () => {
+    new AvalynxSelect('#disabled-select', { defaultValue: '2' });
+});</code></pre>
+
+    <a href="https://github.com/avalynx/avalynx-select" target="_blank" class="btn btn-primary">AvalynxSelect on GitHub</a>
+    <a href="https://github.com/avalynx/" target="_blank" class="btn btn-primary">Avalynx on GitHub</a>
+
+</div>
+</body>
+</html>

--- a/examples/simple-select-event-listeners.html
+++ b/examples/simple-select-event-listeners.html
@@ -16,8 +16,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
     <script>hljs.highlightAll();</script>
 
-    <!-- AvalynxSelect 1.0.0 -->
-    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.0.0/dist/js/avalynx-select.js"></script>
+    <!-- AvalynxSelect 1.1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
 
     <!-- Example helper -->
     <link href="./css/helper.css" rel="stylesheet">

--- a/examples/simple-select-livesearch.html
+++ b/examples/simple-select-livesearch.html
@@ -16,8 +16,8 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
 	<script>hljs.highlightAll();</script>
 
-	<!-- AvalynxSelect 1.0.0 -->
-    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.0.0/dist/js/avalynx-select.js"></script>
+	<!-- AvalynxSelect 1.1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
 
 	<!-- Example helper -->
 	<link href="./css/helper.css" rel="stylesheet">

--- a/examples/simple-select-responsive.html
+++ b/examples/simple-select-responsive.html
@@ -16,8 +16,8 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
 	<script>hljs.highlightAll();</script>
 
-	<!-- AvalynxSelect 1.0.0 -->
-    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.0.0/dist/js/avalynx-select.js"></script>
+	<!-- AvalynxSelect 1.1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
 
 	<!-- Example helper -->
 	<link href="./css/helper.css" rel="stylesheet">

--- a/examples/simple-select.html
+++ b/examples/simple-select.html
@@ -16,8 +16,8 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
 	<script>hljs.highlightAll();</script>
 
-	<!-- AvalynxSelect 1.0.0 -->
-	<script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.0.0/dist/js/avalynx-select.js"></script>
+	<!-- AvalynxSelect 1.1.0 -->
+	<script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.js"></script>
 
 	<!-- Example helper -->
 	<link href="./css/helper.css" rel="stylesheet">

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "avalynx-select",
   "title": "AvalynxSelect",
   "description": "AvalynxSelect is a lightweight, customizable select dropdown component for web applications. It is designed to be used with Bootstrap version 5.3 or higher and does not require any framework dependencies.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/js/avalynx-select.js",
   "module": "dist/js/avalynx-select.esm.js",


### PR DESCRIPTION
Updated examples to use the new AvalynxSelect version 1.1.0. Enhanced Jest tests with extensive test cases for functionalities like initialization, configuration options, live search, item selection, and public API methods to ensure comprehensive coverage.